### PR TITLE
Bump shiro-spring-boot-starter from 1.4.0 to 1.7.1 in /api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -202,7 +202,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring-boot-starter</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.1</version>
 		</dependency>
 		<!-- shiro-redis -->
         <dependency>


### PR DESCRIPTION
Bumps shiro-spring-boot-starter from 1.4.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-spring-boot-starter dependency-type: direct:production ...